### PR TITLE
Avoid create 0byte files

### DIFF
--- a/example/config_avoid_create_0byte_file.yml
+++ b/example/config_avoid_create_0byte_file.yml
@@ -1,0 +1,55 @@
+hdfs_example: &hdfs_example
+  config_files:
+    - /etc/hadoop/conf/core-site.xml
+    - /etc/hadoop/conf/hdfs-site.xml
+  config:
+    fs.defaultFS: 'hdfs://hadoop-nn1:8020'
+    fs.hdfs.impl: 'org.apache.hadoop.hdfs.DistributedFileSystem'
+    fs.file.impl: 'org.apache.hadoop.fs.LocalFileSystem'
+
+local_fs_example: &local_fs_example
+  config:
+    fs.defaultFS: 'file:///'
+    fs.hdfs.impl: 'org.apache.hadoop.fs.RawLocalFileSystem'
+    fs.file.impl: 'org.apache.hadoop.fs.RawLocalFileSystem'
+    io.compression.codecs: 'org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.BZip2Codec'
+
+exec:
+  min_output_tasks: 10
+
+in:
+  type: file
+  path_prefix: example/data
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: '"'
+    header_line: true
+    stop_on_invalid_record: true
+    columns:
+    - {name: id, type: long}
+    - {name: account, type: long}
+    - {name: time, type: timestamp, format: '%Y-%m-%d %H:%M:%S'}
+    - {name: purchase, type: timestamp, format: '%Y%m%d'}
+    - {name: comment, type: string}
+
+
+out:
+  type: hdfs
+  <<: *local_fs_example
+  path_prefix: /tmp/embulk-output-hdfs_example/file_
+  file_ext: csv
+  delete_in_advance: FILE_ONLY
+  formatter:
+    type: csv
+    newline: CRLF
+    newline_in_field: LF
+    header_line: false
+    charset: UTF-8
+    quote_policy: NONE
+    quote: '"'
+    escape: '\'
+    null_string: ''
+    default_timezone: UTC


### PR DESCRIPTION
When loading small files and using ScatterExecutor, sometimes this plugin creates lots of empty files.
This behaviour may become the cause that the namenode heap size increases.
So, change the behaviour to NOT create when no data is added.

The log is below. Because it is difficult to write the test, I added only example. (TODO. SHOULD ADD THE TEST)

```
[embulk-output-hdfs] embulk run example/config_avoid_create_0byte_file.yml -Ilib
2016-04-27 10:50:00.436 +0900: Embulk v0.8.8
2016-04-27 10:50:02.495 +0900 [INFO] (0001:transaction): Loaded plugin embulk/output/hdfs from a load path
2016-04-27 10:50:02.578 +0900 [INFO] (0001:transaction): Listing local files at directory 'example' filtering filename by prefix 'data'
2016-04-27 10:50:02.587 +0900 [INFO] (0001:transaction): Loading files [example/data.csv]
2016-04-27 10:50:02.695 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 10 = input tasks 1 * 10
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
2016-04-27 10:50:03.421 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2016-04-27 10:50:03.631 +0900 [INFO] (0016:task-0000): Uploading '/tmp/embulk-output-hdfs_example/file_000.00.csv'
2016-04-27 10:50:03.633 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2016-04-27 10:50:03.639 +0900 [INFO] (main): Committed.
2016-04-27 10:50:03.639 +0900 [INFO] (main): Next config diff: {"in":{"last_path":"example/data.csv"},"out":{}}
```
