### PR TITLE
Add mode option with replace mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 jdk:
   - openjdk7
@@ -7,3 +8,7 @@ script:
   - ./gradlew test
 after_success:
   - ./gradlew jacocoTestReport coveralls
+addons:
+  hosts:
+    - example.com
+  hostname: example.com

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ If you use `hadoop` user (hdfs admin user) as `doas`, and if `delete_in_advance`
 this means `embulk-output-hdfs` can destroy your hdfs.
 So, please be careful when you use `delete_in_advance` option and `doas` option ...
 
+## About DELETE
+
+When this plugin deletes files or directories, use [`Hadoop Trash API`](https://hadoop.apache.org/docs/r2.8.0/api/org/apache/hadoop/fs/Trash.html). So, you can find them in the trash during `fs.trash.interval`.
+
 ## Modes
 
 * **abort_if_exist**:

--- a/example/config_deprecated_option.yml
+++ b/example/config_deprecated_option.yml
@@ -6,14 +6,12 @@ hdfs_example: &hdfs_example
     fs.defaultFS: 'hdfs://hadoop-nn1:8020'
     fs.hdfs.impl: 'org.apache.hadoop.hdfs.DistributedFileSystem'
     fs.file.impl: 'org.apache.hadoop.fs.LocalFileSystem'
-    fs.trash.interval: 3600
 
 local_fs_example: &local_fs_example
   config:
     fs.defaultFS: 'file:///'
     fs.hdfs.impl: 'org.apache.hadoop.fs.RawLocalFileSystem'
     fs.file.impl: 'org.apache.hadoop.fs.RawLocalFileSystem'
-    fs.trash.interval: 3600
     io.compression.codecs: 'org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.BZip2Codec'
 
 in:
@@ -40,7 +38,7 @@ out:
   <<: *local_fs_example
   path_prefix: /tmp/embulk-output-hdfs_example/file_
   file_ext: csv
-  mode: replace
+  delete_in_advance: FILE_ONLY
   formatter:
     type: csv
     newline: CRLF

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
@@ -80,7 +80,6 @@ public class HdfsFileOutput
         finally {
             buffer.release();
         }
-
     }
 
     @Override
@@ -99,7 +98,8 @@ public class HdfsFileOutput
     private void write(final Buffer buffer)
             throws RetryExecutor.RetryGiveupException
     {
-        re.run(new RetryExecutor.Retryable<Void>() {
+        re.run(new RetryExecutor.Retryable<Void>()
+        {
             @Override
             public Void call()
                     throws Exception

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
@@ -23,7 +23,6 @@ public class HdfsFileOutput
             .withRetryLimit(3)
             .withMaxRetryWait(500) // ms
             .withMaxRetryWait(10 * 60 * 1000); // ms
-    private final ImmutableList.Builder<String> outputPaths = ImmutableList.builder();
 
     private final HdfsClient hdfsClient;
     private final int taskIdx;
@@ -59,9 +58,7 @@ public class HdfsFileOutput
     @Override
     public TaskReport commit()
     {
-        TaskReport report = Exec.newTaskReport();
-        report.set("output_paths", outputPaths.build());
-        return report;
+        return Exec.newTaskReport();
     }
 
     @Override
@@ -80,7 +77,6 @@ public class HdfsFileOutput
             if (o == null) {
                 o = hdfsClient.create(currentPath, overwrite);
                 logger.info("Uploading '{}'", currentPath);
-                outputPaths.add(currentPath.toString());
             }
             write(buffer);
         }

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
@@ -1,0 +1,170 @@
+package org.embulk.output.hdfs;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.Path;
+import org.embulk.config.TaskReport;
+import org.embulk.output.hdfs.client.HdfsClient;
+import org.embulk.spi.Buffer;
+import org.embulk.spi.Exec;
+import org.embulk.spi.FileOutput;
+import org.embulk.spi.TransactionalFileOutput;
+import org.embulk.spi.util.RetryExecutor;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+
+public class HdfsFileOutput
+        implements FileOutput, TransactionalFileOutput
+{
+    private static final Logger logger = Exec.getLogger(HdfsFileOutput.class);
+    private final RetryExecutor re = RetryExecutor.retryExecutor()
+            .withRetryLimit(3)
+            .withMaxRetryWait(500) // ms
+            .withMaxRetryWait(10 * 60 * 1000); // ms
+    private final ImmutableList.Builder<Path> outputPaths = ImmutableList.builder();
+
+    private final HdfsClient hdfsClient;
+    private final int taskIdx;
+    private final String pathPrefix;
+    private final String sequenceFormat;
+    private final String fileExt;
+    private final boolean overwrite;
+
+    private int fileIdx = 0;
+    private Path currentPath = null;
+    private OutputStream o = null;
+
+    HdfsFileOutput(HdfsFileOutputPlugin.PluginTask task, String pathPrefix, int taskIdx)
+    {
+        this.hdfsClient = HdfsClient.build(task);
+        this.pathPrefix = pathPrefix;
+        this.taskIdx = taskIdx;
+        this.sequenceFormat = task.getSequenceFormat();
+        this.fileExt = task.getFileExt();
+        this.overwrite = task.getOverwrite();
+    }
+
+    HdfsFileOutput(HdfsFileOutputPlugin.PluginTask task, String workspace, String pathPrefix, int taskIdx)
+    {
+        this(task, Paths.get(workspace, pathPrefix).toString(), taskIdx);
+    }
+
+    @Override
+    public void abort()
+    {
+    }
+
+    @Override
+    public TaskReport commit()
+    {
+        TaskReport report = Exec.newTaskReport();
+        report.set("output_paths", outputPaths.build());
+        return report;
+    }
+
+    @Override
+    public void nextFile()
+    {
+        closeCurrentStream();
+        currentPath = newPath();
+        fileIdx++;
+    }
+
+    @Override
+    public void add(Buffer buffer)
+    {
+        try {
+            // this implementation is for creating file when there is data.
+            if (o == null) {
+                o = hdfsClient.create(currentPath, overwrite);
+                logger.info("Uploading '{}'", currentPath);
+                outputPaths.add(currentPath);
+            }
+            write(buffer);
+        }
+        catch (RetryExecutor.RetryGiveupException e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            buffer.release();
+        }
+
+    }
+
+    @Override
+    public void finish()
+    {
+        closeCurrentStream();
+    }
+
+    @Override
+    public void close()
+    {
+        closeCurrentStream();
+        hdfsClient.close();
+    }
+
+    private void write(final Buffer buffer)
+            throws RetryExecutor.RetryGiveupException
+    {
+        re.run(new RetryExecutor.Retryable<Void>() {
+            @Override
+            public Void call()
+                    throws Exception
+            {
+                o.write(buffer.array(), buffer.offset(), buffer.limit());
+                return null;
+            }
+
+            @Override
+            public boolean isRetryableException(Exception exception)
+            {
+                return true; // TODO: which Exception is retryable?
+            }
+
+            @Override
+            public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                    throws RetryExecutor.RetryGiveupException
+            {
+                String m = String.format(
+                        "%s. (Retry: Count: %d, Limit: %d, Wait: %d ms)",
+                        exception.getMessage(),
+                        retryCount,
+                        retryLimit,
+                        retryWait);
+                logger.warn(m, exception);
+            }
+
+            @Override
+            public void onGiveup(Exception firstException, Exception lastException)
+                    throws RetryExecutor.RetryGiveupException
+            {
+            }
+        });
+    }
+
+    private Path newPath()
+    {
+        return new Path(pathPrefix + getSequence() + fileExt);
+    }
+
+    private String getSequence()
+    {
+        return String.format(sequenceFormat, taskIdx, fileIdx);
+    }
+
+    private void closeCurrentStream()
+    {
+        if (o != null) {
+            try {
+                o.close();
+                o = null;
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
@@ -23,7 +23,7 @@ public class HdfsFileOutput
             .withRetryLimit(3)
             .withMaxRetryWait(500) // ms
             .withMaxRetryWait(10 * 60 * 1000); // ms
-    private final ImmutableList.Builder<Path> outputPaths = ImmutableList.builder();
+    private final ImmutableList.Builder<String> outputPaths = ImmutableList.builder();
 
     private final HdfsClient hdfsClient;
     private final int taskIdx;
@@ -80,7 +80,7 @@ public class HdfsFileOutput
             if (o == null) {
                 o = hdfsClient.create(currentPath, overwrite);
                 logger.info("Uploading '{}'", currentPath);
-                outputPaths.add(currentPath);
+                outputPaths.add(currentPath.toString());
             }
             write(buffer);
         }

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutput.java
@@ -1,8 +1,8 @@
 package org.embulk.output.hdfs;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.fs.Path;
 import org.embulk.config.TaskReport;
+import org.embulk.output.hdfs.HdfsFileOutputPlugin.PluginTask;
 import org.embulk.output.hdfs.client.HdfsClient;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.Exec;
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Paths;
 
 public class HdfsFileOutput
         implements FileOutput, TransactionalFileOutput
@@ -35,19 +34,14 @@ public class HdfsFileOutput
     private Path currentPath = null;
     private OutputStream o = null;
 
-    HdfsFileOutput(HdfsFileOutputPlugin.PluginTask task, String pathPrefix, int taskIdx)
+    public HdfsFileOutput(PluginTask task, String pathPrefix, boolean overwrite, int taskIdx)
     {
         this.hdfsClient = HdfsClient.build(task);
         this.pathPrefix = pathPrefix;
         this.taskIdx = taskIdx;
         this.sequenceFormat = task.getSequenceFormat();
         this.fileExt = task.getFileExt();
-        this.overwrite = task.getOverwrite();
-    }
-
-    HdfsFileOutput(HdfsFileOutputPlugin.PluginTask task, String workspace, String pathPrefix, int taskIdx)
-    {
-        this(task, Paths.get(workspace, pathPrefix).toString(), taskIdx);
+        this.overwrite = overwrite;
     }
 
     @Override

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -138,10 +138,8 @@ public class HdfsFileOutputPlugin
         String outputDir = getOutputSampleDir(task);
         String safeWsWithOutput = Paths.get(task.getSafeWorkspace(), getOutputSampleDir(task)).toString();
 
-        if (!hdfsClient.swapDirectory(safeWsWithOutput, outputDir)) {
-            throw new DataException(String.format("Failed to swap: src: %s, dst: %s", safeWsWithOutput, outputDir));
-        }
-        logger.info("Swapped: src: {}, dst: {}", safeWsWithOutput, outputDir);
+        hdfsClient.overwriteDirectory(safeWsWithOutput, outputDir);
+        logger.info("Store {} To {}", safeWsWithOutput, outputDir);
     }
 
     @Override

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -98,13 +98,13 @@ public class HdfsFileOutputPlugin
                 throw new ConfigException("`delete_in_advance` must be `NONE` if atomic mode."); // TODO
             }
             if (task.getOverwrite()) {
-                logger.info("Replace directory {} if exists.", sampleDir(task));
+                logger.info("Replace directory {} if exists.", getOutputSampleDir(task));
             }
 
             String safeWorkspace = SafeWorkspaceName.build(task.getWorkspace());
             logger.info("Use as a workspace: {}", safeWorkspace);
 
-            String safeWsWithOutput = Paths.get(safeWorkspace, sampleDir(task)).toString();
+            String safeWsWithOutput = Paths.get(safeWorkspace, getOutputSampleDir(task)).toString();
             logger.debug("The actual workspace must be with output dirs: {}", safeWsWithOutput);
             if (!hdfsClient.mkdirs(safeWsWithOutput)) {
                 throw new ConfigException(String.format("Failed to make a directory: %s", safeWsWithOutput));
@@ -141,7 +141,7 @@ public class HdfsFileOutputPlugin
             List<TaskReport> successTaskReports)
     {
         PluginTask task = taskSource.loadTask(PluginTask.class);
-        String outputDir = sampleDir(task);
+        String outputDir = getOutputSampleDir(task);
 
         for (TaskReport successTaskReport : successTaskReports) {
             List outputPaths = successTaskReport.get(List.class, "output_paths");
@@ -157,7 +157,7 @@ public class HdfsFileOutputPlugin
 
         if (task.getAtomicMode()) {
             HdfsClient hdfsClient = HdfsClient.build(task);
-            String safeWsWithOutput = Paths.get(task.getSafeWorkspace(), sampleDir(task)).toString();
+            String safeWsWithOutput = Paths.get(task.getSafeWorkspace(), getOutputSampleDir(task)).toString();
             if (!hdfsClient.swapDirectory(safeWsWithOutput, outputDir)) {
                 throw new DataException(String.format("Failed to swap: src: %s, dst: %s", safeWsWithOutput, outputDir));
             }
@@ -178,7 +178,7 @@ public class HdfsFileOutputPlugin
         }
     }
 
-    private String sampleDir(PluginTask task)
+    private String getOutputSampleDir(PluginTask task)
     {
         String pathPrefix = StrftimeUtil.strftime(task.getPathPrefix(), task.getRewindSeconds());
         return SamplePath.getDir(pathPrefix, task.getSequenceFormat(), task.getFileExt());

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -23,6 +23,7 @@ import org.jruby.embed.ScriptingContainer;
 import org.slf4j.Logger;
 
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -139,7 +140,7 @@ public class HdfsFileOutputPlugin
         String safeWsWithOutput = Paths.get(task.getSafeWorkspace(), getOutputSampleDir(task)).toString();
 
         hdfsClient.overwriteDirectory(safeWsWithOutput, outputDir);
-        logger.info("Store {} To {}", safeWsWithOutput, outputDir);
+        logger.info("Store: {} >>> {}", safeWsWithOutput, outputDir);
     }
 
     @Override
@@ -159,10 +160,12 @@ public class HdfsFileOutputPlugin
         String outputDir = getOutputSampleDir(task);
 
         for (TaskReport successTaskReport : successTaskReports) {
+
             List outputPaths = successTaskReport.get(List.class, "output_paths");
             for (Object path : outputPaths) {
+
                 if (task.getAtomicMode()) {
-                    logger.info("Created and Moved: {} to {}", path, outputDir);
+                    logger.info("Created and Moved: {} >>> {}", path, outputDir);
                 }
                 else {
                     logger.info("Created: {}", path);

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -169,15 +169,13 @@ public class HdfsFileOutputPlugin
     public TransactionalFileOutput open(TaskSource taskSource, int taskIndex)
     {
         PluginTask task = taskSource.loadTask(PluginTask.class);
-        String pathPrefix;
+        String pathPrefix = StrftimeUtil.strftime(task.getPathPrefix(), task.getRewindSeconds());;
         if (task.getAtomicMode()) {
-            pathPrefix = task.getSafeWorkspace();
+            return new HdfsFileOutput(task, task.getSafeWorkspace(), pathPrefix, taskIndex);
         }
         else {
-            pathPrefix = StrftimeUtil.strftime(task.getPathPrefix(), task.getRewindSeconds());
+            return new HdfsFileOutput(task, pathPrefix, taskIndex);
         }
-
-        return new HdfsFileOutput(task, pathPrefix, taskIndex);
     }
 
     private String sampleDir(PluginTask task)

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -60,7 +60,11 @@ public class HdfsFileOutputPlugin
         Optional<String> getDoas();
 
         @Deprecated
-        enum DeleteInAdvancePolicy{ NONE, FILE_ONLY, RECURSIVE}
+        enum DeleteInAdvancePolicy
+        {
+            NONE, FILE_ONLY, RECURSIVE
+        }
+
         @Deprecated  // Please Use `mode` option
         @Config("delete_in_advance")
         @ConfigDefault("null")
@@ -71,6 +75,7 @@ public class HdfsFileOutputPlugin
         String getWorkspace();
 
         String getSafeWorkspace();
+
         void setSafeWorkspace(String safeWorkspace);
     }
 
@@ -97,7 +102,8 @@ public class HdfsFileOutputPlugin
         avoidDatabindError(task);
 
         Tx tx = task.getMode().newTx();
-        return tx.transaction(task, new ControlRun() {
+        return tx.transaction(task, new ControlRun()
+        {
             @Override
             public List<TaskReport> run()
             {

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -15,7 +15,6 @@ import org.embulk.output.hdfs.client.HdfsClient;
 import org.embulk.output.hdfs.util.SafeWorkspaceName;
 import org.embulk.output.hdfs.util.SamplePath;
 import org.embulk.output.hdfs.util.StrftimeUtil;
-import org.embulk.spi.DataException;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.TransactionalFileOutput;
@@ -23,7 +22,6 @@ import org.jruby.embed.ScriptingContainer;
 import org.slf4j.Logger;
 
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -156,22 +154,6 @@ public class HdfsFileOutputPlugin
             int taskCount,
             List<TaskReport> successTaskReports)
     {
-        PluginTask task = taskSource.loadTask(PluginTask.class);
-        String outputDir = getOutputSampleDir(task);
-
-        for (TaskReport successTaskReport : successTaskReports) {
-
-            List outputPaths = successTaskReport.get(List.class, "output_paths");
-            for (Object path : outputPaths) {
-
-                if (task.getAtomicMode()) {
-                    logger.info("Created and Moved: {} >>> {}", path, outputDir);
-                }
-                else {
-                    logger.info("Created: {}", path);
-                }
-            }
-        }
     }
 
     @Override

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -11,7 +11,9 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
+import org.embulk.output.hdfs.ModeTask.Mode;
 import org.embulk.output.hdfs.client.HdfsClient;
+import org.embulk.output.hdfs.compat.ModeCompat;
 import org.embulk.output.hdfs.util.SafeWorkspaceName;
 import org.embulk.output.hdfs.util.SamplePath;
 import org.embulk.output.hdfs.util.StrftimeUtil;
@@ -26,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.embulk.output.hdfs.HdfsFileOutputPlugin.PluginTask.DeleteInAdvancePolicy;
+import static org.embulk.output.hdfs.ModeTask.Mode.REPLACE;
+import static org.embulk.output.hdfs.compat.ModeCompat.getMode;
 
 public class HdfsFileOutputPlugin
         implements FileOutputPlugin
@@ -33,7 +37,7 @@ public class HdfsFileOutputPlugin
     private static final Logger logger = Exec.getLogger(HdfsFileOutputPlugin.class);
 
     public interface PluginTask
-            extends Task
+            extends Task, ModeTask
     {
         @Config("config_files")
         @ConfigDefault("[]")
@@ -57,22 +61,21 @@ public class HdfsFileOutputPlugin
         @ConfigDefault("0")
         int getRewindSeconds();
 
+        @Deprecated  // Please Use `mode` option
         @Config("overwrite")
-        @ConfigDefault("false")
-        boolean getOverwrite();
+        @ConfigDefault("null")
+        Optional<Boolean> getOverwrite();
 
         @Config("doas")
         @ConfigDefault("null")
         Optional<String> getDoas();
 
+        @Deprecated
         enum DeleteInAdvancePolicy{ NONE, FILE_ONLY, RECURSIVE}
+        @Deprecated  // Please Use `mode` option
         @Config("delete_in_advance")
-        @ConfigDefault("\"NONE\"")
-        DeleteInAdvancePolicy getDeleteInAdvance();
-
-        @Config("atomic")
-        @ConfigDefault("false")
-        boolean getAtomic();
+        @ConfigDefault("null")
+        Optional<DeleteInAdvancePolicy> getDeleteInAdvance();
 
         @Config("workspace")
         @ConfigDefault("\"/tmp\"")

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -75,7 +75,6 @@ public class HdfsFileOutputPlugin
         String getWorkspace();
 
         String getSafeWorkspace();
-
         void setSafeWorkspace(String safeWorkspace);
     }
 
@@ -90,7 +89,8 @@ public class HdfsFileOutputPlugin
     //  at [Source: N/A; line: -1, column: -1]
     private void avoidDatabindError(PluginTask task)
     {
-        task.setSafeWorkspace(task.getWorkspace());
+        // Set default value
+        task.setSafeWorkspace("");
     }
 
     @Override

--- a/src/main/java/org/embulk/output/hdfs/ModeTask.java
+++ b/src/main/java/org/embulk/output/hdfs/ModeTask.java
@@ -26,7 +26,7 @@ public interface ModeTask
         extends Task
 {
     @Config("mode")
-    @ConfigDefault("abort_if_exist")
+    @ConfigDefault("\"abort_if_exist\"")
     Mode getMode();
     void setMode(Mode mode);
 

--- a/src/main/java/org/embulk/output/hdfs/ModeTask.java
+++ b/src/main/java/org/embulk/output/hdfs/ModeTask.java
@@ -28,6 +28,7 @@ public interface ModeTask
     @Config("mode")
     @ConfigDefault("\"abort_if_exist\"")
     Mode getMode();
+
     void setMode(Mode mode);
 
     enum Mode
@@ -57,8 +58,7 @@ public interface ModeTask
         @SuppressWarnings("unused")
         public static Mode fromString(String value)
         {
-            switch (value)
-            {
+            switch (value) {
                 case "abort_if_exist":
                     return ABORT_IF_EXIST;
                 case "overwrite":
@@ -91,8 +91,7 @@ public interface ModeTask
 
         public Tx newTx()
         {
-            switch (this)
-            {
+            switch (this) {
                 case ABORT_IF_EXIST:
                     return new AbortIfExistTx();
                 case DELETE_FILES_IN_ADVANCE:
@@ -109,5 +108,4 @@ public interface ModeTask
         }
 
     }
-
 }

--- a/src/main/java/org/embulk/output/hdfs/ModeTask.java
+++ b/src/main/java/org/embulk/output/hdfs/ModeTask.java
@@ -1,0 +1,113 @@
+package org.embulk.output.hdfs;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigException;
+import org.embulk.config.Task;
+import org.embulk.output.hdfs.transaction.AbortIfExistTx;
+import org.embulk.output.hdfs.transaction.DeleteFilesInAdvanceTx;
+import org.embulk.output.hdfs.transaction.DeleteRecursiveInAdvanceTx;
+import org.embulk.output.hdfs.transaction.OverwriteTx;
+import org.embulk.output.hdfs.transaction.ReplaceTx;
+import org.embulk.output.hdfs.transaction.Tx;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.util.Locale;
+
+public interface ModeTask
+        extends Task
+{
+    @Config("mode")
+    @ConfigDefault("abort_if_exist")
+    Mode getMode();
+    void setMode(Mode mode);
+
+    enum Mode
+    {
+        ABORT_IF_EXIST,
+        OVERWRITE,
+        DELETE_FILES_IN_ADVANCE,
+        DELETE_RECURSIVE_IN_ADVANCE,
+        REPLACE;
+
+        private static final Logger logger = Exec.getLogger(Mode.class);
+
+        @Deprecated  // For compat
+        public boolean isDefaultMode()
+        {
+            return this.equals(ABORT_IF_EXIST);
+        }
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return name().toLowerCase(Locale.ENGLISH);
+        }
+
+        @JsonCreator
+        @SuppressWarnings("unused")
+        public static Mode fromString(String value)
+        {
+            switch (value)
+            {
+                case "abort_if_exist":
+                    return ABORT_IF_EXIST;
+                case "overwrite":
+                    return OVERWRITE;
+                case "delete_files_in_advance":
+                    return DELETE_FILES_IN_ADVANCE;
+                case "delete_recursive_in_advance":
+                    return DELETE_RECURSIVE_IN_ADVANCE;
+                case "replace":
+                    return REPLACE;
+                default:
+                    throw new ConfigException(String.format(
+                            "Unknown mode `%s`. Supported mode is %s",
+                            value,
+                            Joiner.on(", ").join(
+                                    Lists.transform(Lists.newArrayList(Mode.values()), new Function<Mode, String>()
+                                    {
+                                        @Nullable
+                                        @Override
+                                        public String apply(@Nullable Mode input)
+                                        {
+                                            assert input != null;
+                                            return String.format("`%s`", input.toString());
+                                        }
+                                    })
+                            )
+                    ));
+            }
+        }
+
+        public Tx newTx()
+        {
+            switch (this)
+            {
+                case ABORT_IF_EXIST:
+                    return new AbortIfExistTx();
+                case DELETE_FILES_IN_ADVANCE:
+                    return new DeleteFilesInAdvanceTx();
+                case DELETE_RECURSIVE_IN_ADVANCE:
+                    return new DeleteRecursiveInAdvanceTx();
+                case OVERWRITE:
+                    return new OverwriteTx();
+                case REPLACE:
+                    return new ReplaceTx();
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
+++ b/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
@@ -247,14 +247,14 @@ public class HdfsClient
                     throws Exception
             {
                 if (fs.exists(dst)) {
-                    logger.info("Overwrite: {} By {}", dst, src);
+                    logger.info("Overwrite: {} >>> {}", src, dst);
                     if (!new Trash(conf).moveToTrash(dst)) {
-                        throw new IllegalStateException(String.format("Failed to Move %s to Trash", dst.getName()));
+                        throw new IllegalStateException(String.format("Failed to MoveToTrash: %s", dst.toString()));
                     }
                     logger.debug("MoveToTrash: {}", dst);
                 }
                 FileContext.getFileContext(conf).rename(src, dst, Options.Rename.NONE);
-                logger.debug("Move: {} To {}", src, dst);
+                logger.debug("Move: {} >>> {}", src, dst);
                 return null;
             }
         });

--- a/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
+++ b/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
@@ -10,6 +10,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.Trash;
 import org.embulk.config.ConfigException;
 import org.embulk.output.hdfs.HdfsFileOutputPlugin;
+import org.embulk.spi.DataException;
 import org.embulk.spi.Exec;
 import org.embulk.spi.util.RetryExecutor;
 import org.slf4j.Logger;
@@ -234,12 +235,12 @@ public class HdfsClient
         });
     }
 
-    public void overwriteDirectory(String src, String dst)
+    public void renameDirectory(String src, String dst, boolean overwrite)
     {
-        overwriteDirectory(new Path(src), new Path(dst));
+        renameDirectory(new Path(src), new Path(dst), overwrite);
     }
 
-    public Void overwriteDirectory(final Path src, final Path dst)
+    public Void renameDirectory(final Path src, final Path dst, final boolean overwrite)
     {
         return run(new Retryable<Void>() {
             @Override

--- a/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
+++ b/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
@@ -1,0 +1,203 @@
+package org.embulk.output.hdfs.client;
+
+import com.google.common.base.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.embulk.config.ConfigException;
+import org.embulk.output.hdfs.HdfsFileOutputPlugin;
+import org.embulk.spi.Exec;
+import org.embulk.spi.util.RetryExecutor;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+public class HdfsClient
+{
+    public static HdfsClient build(HdfsFileOutputPlugin.PluginTask task)
+    {
+        Configuration conf = buildConfiguration(task.getConfigFiles(), task.getConfig());
+        return new HdfsClient(conf, task.getDoas());
+    };
+
+    public static Configuration buildConfiguration(List<String> configFiles, Map<String, String> configs)
+    {
+        Configuration c = new Configuration();
+        for (String configFile : configFiles) {
+            File file = new File(configFile);
+            try {
+                c.addResource(file.toURI().toURL());
+            }
+            catch (MalformedURLException e) {
+                throw new ConfigException(e);
+            }
+        }
+        for (Map.Entry<String, String> config : configs.entrySet()) {
+            c.set(config.getKey(), config.getValue());
+        }
+        return c;
+    }
+
+    private static Logger logger = Exec.getLogger(HdfsClient.class);
+    private final Configuration conf;
+    private final FileSystem fs;
+    private final Optional<String> user;
+    private final RetryExecutor re = RetryExecutor.retryExecutor()
+            .withRetryLimit(3)
+            .withMaxRetryWait(500)             // ms
+            .withMaxRetryWait(10 * 60 * 1000); // ms
+
+    private HdfsClient(Configuration conf, Optional<String> user)
+    {
+        this.conf = conf;
+        this.user = user;
+        this.fs = getFs(conf, user);
+    }
+
+    private abstract static class Retryable<T>
+            implements RetryExecutor.Retryable<T>
+    {
+        @Override
+        public boolean isRetryableException(Exception exception)
+        {
+            return true; // TODO: which Exception is retryable?
+        }
+
+        @Override
+        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                throws RetryExecutor.RetryGiveupException
+        {
+            String m = String.format(
+                    "%s. (Retry: Count: %d, Limit: %d, Wait: %d ms)",
+                    exception.getMessage(),
+                    retryCount,
+                    retryLimit,
+                    retryWait);
+            logger.warn(m, exception);
+        }
+
+        @Override
+        public void onGiveup(Exception firstException, Exception lastException)
+                throws RetryExecutor.RetryGiveupException
+        {
+        }
+
+    }
+
+    private <T>T run(Retryable<T> retryable)
+    {
+        try {
+            return re.run(retryable);
+        }
+        catch (RetryExecutor.RetryGiveupException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private FileSystem getFs(Configuration conf, Optional<String> user)
+    {
+        if (user.isPresent()) {
+            return getFs(conf, user.get());
+        }
+        else {
+            return getFs(conf);
+        }
+    }
+
+    private FileSystem getFs(final Configuration conf, final String user)
+    {
+        return run(new Retryable<FileSystem>() {
+            @Override
+            public FileSystem call()
+                    throws Exception
+            {
+                URI uri = FileSystem.getDefaultUri(conf);
+                return FileSystem.get(uri, conf, user);
+            }
+        });
+    }
+
+    private FileSystem getFs(final Configuration conf)
+    {
+        return run(new Retryable<FileSystem>() {
+            @Override
+            public FileSystem call()
+                    throws Exception
+            {
+                return FileSystem.get(conf);
+            }
+        });
+    }
+
+    public FileStatus[] glob(final Path globPath)
+    {
+        return run(new Retryable<FileStatus[]>()
+        {
+            @Override
+            public FileStatus[] call()
+                    throws Exception
+            {
+                return fs.globStatus(globPath);
+            }
+        });
+    }
+
+    public boolean delete(final Path path, final boolean recursive)
+    {
+        return run(new Retryable<Boolean>()
+        {
+            @Override
+            public Boolean call()
+                    throws Exception
+            {
+                return fs.delete(path, recursive);
+            }
+        });
+    }
+
+    public void globAndRemove(final Path globPath)
+    {
+        for (final FileStatus fileStatus : glob(globPath)) {
+            if (fileStatus.isDirectory()) {
+                logger.debug("Skip {} because {} is a directory.",
+                        fileStatus.getPath(), fileStatus.getPath());
+                continue;
+            }
+            logger.debug("Remove: {}", fileStatus.getPath());
+            boolean isRemoved = delete(fileStatus.getPath(), false);
+            if (!isRemoved) {
+                throw new RuntimeException(String.format("Remove Failed: %s", fileStatus.getPath()));
+            }
+        }
+    }
+
+    public void globAndRemoveRecursive(final Path globPath)
+    {
+        for (final FileStatus fileStatus : glob(globPath)) {
+            logger.debug("Remove: {}", fileStatus.getPath());
+            boolean isRemoved = delete(fileStatus.getPath(), true);
+            if (!isRemoved) {
+                throw new RuntimeException(String.format("Remove Failed: %s", fileStatus.getPath()));
+            }
+        }
+    }
+
+    public OutputStream create(final Path path, final boolean overwrite)
+    {
+        return run(new Retryable<OutputStream>()
+        {
+            @Override
+            public OutputStream call()
+                    throws Exception
+            {
+                return fs.create(path, overwrite);
+            }
+        });
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
+++ b/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
@@ -248,6 +248,9 @@ public class HdfsClient
                     throws Exception
             {
                 if (fs.exists(dst)) {
+                    if (!overwrite) {
+                        throw new DataException(String.format("Directory Exists: %s", dst.toString()));
+                    }
                     logger.info("Overwrite: {} >>> {}", src, dst);
                     if (!new Trash(conf).moveToTrash(dst)) {
                         throw new IllegalStateException(String.format("Failed to MoveToTrash: %s", dst.toString()));

--- a/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
+++ b/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
@@ -2,8 +2,11 @@ package org.embulk.output.hdfs.client;
 
 import com.google.common.base.Optional;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.embulk.config.ConfigException;
 import org.embulk.output.hdfs.HdfsFileOutputPlugin;
@@ -197,6 +200,53 @@ public class HdfsClient
                     throws Exception
             {
                 return fs.create(path, overwrite);
+            }
+        });
+    }
+
+    public boolean mkdirs(String path)
+    {
+        return mkdirs(new Path(path));
+    }
+
+    public boolean mkdirs(final Path path)
+    {
+        return run(new Retryable<Boolean>() {
+            @Override
+            public Boolean call()
+                    throws Exception
+            {
+                return fs.mkdirs(path);
+            }
+        });
+    }
+
+    public void close()
+    {
+        run(new Retryable<Void>() {
+            @Override
+            public Void call()
+                    throws Exception
+            {
+                fs.close();
+                return null;
+            }
+        });
+    }
+
+    public boolean swapDirectory(String src, String dst)
+    {
+        return swapDirectory(new Path(src), new Path(dst));
+    }
+
+    public boolean swapDirectory(final Path src, final Path dst)
+    {
+        return run(new Retryable<Boolean>() {
+            @Override
+            public Boolean call()
+                    throws Exception
+            {
+                return FileUtil.copy(fs, src, fs, dst, true, true, conf);
             }
         });
     }

--- a/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
+++ b/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
@@ -28,7 +28,9 @@ public class HdfsClient
     {
         Configuration conf = buildConfiguration(task.getConfigFiles(), task.getConfig());
         return new HdfsClient(conf, task.getDoas());
-    };
+    }
+
+    ;
 
     public static Configuration buildConfiguration(List<String> configFiles, Map<String, String> configs)
     {
@@ -91,10 +93,9 @@ public class HdfsClient
                 throws RetryExecutor.RetryGiveupException
         {
         }
-
     }
 
-    private <T>T run(Retryable<T> retryable)
+    private <T> T run(Retryable<T> retryable)
     {
         try {
             return re.run(retryable);
@@ -116,7 +117,8 @@ public class HdfsClient
 
     private FileSystem getFs(final Configuration conf, final String user)
     {
-        return run(new Retryable<FileSystem>() {
+        return run(new Retryable<FileSystem>()
+        {
             @Override
             public FileSystem call()
                     throws Exception
@@ -129,7 +131,8 @@ public class HdfsClient
 
     private FileSystem getFs(final Configuration conf)
     {
-        return run(new Retryable<FileSystem>() {
+        return run(new Retryable<FileSystem>()
+        {
             @Override
             public FileSystem call()
                     throws Exception
@@ -212,7 +215,8 @@ public class HdfsClient
 
     public boolean mkdirs(final Path path)
     {
-        return run(new Retryable<Boolean>() {
+        return run(new Retryable<Boolean>()
+        {
             @Override
             public Boolean call()
                     throws Exception
@@ -224,7 +228,8 @@ public class HdfsClient
 
     public void close()
     {
-        run(new Retryable<Void>() {
+        run(new Retryable<Void>()
+        {
             @Override
             public Void call()
                     throws Exception
@@ -235,30 +240,30 @@ public class HdfsClient
         });
     }
 
-    public void renameDirectory(String src, String dst, boolean overwrite)
+    public void renameDirectory(String src, String dst, boolean trashIfExists)
     {
-        renameDirectory(new Path(src), new Path(dst), overwrite);
+        renameDirectory(new Path(src), new Path(dst), trashIfExists);
     }
 
-    public Void renameDirectory(final Path src, final Path dst, final boolean overwrite)
+    public void renameDirectory(final Path src, final Path dst, final boolean trashIfExists)
     {
-        return run(new Retryable<Void>() {
+        run(new Retryable<Void>()
+        {
             @Override
             public Void call()
                     throws Exception
             {
                 if (fs.exists(dst)) {
-                    if (!overwrite) {
+                    if (!trashIfExists) {
                         throw new DataException(String.format("Directory Exists: %s", dst.toString()));
                     }
-                    logger.info("Overwrite: {} >>> {}", src, dst);
-                    if (!new Trash(conf).moveToTrash(dst)) {
-                        throw new IllegalStateException(String.format("Failed to MoveToTrash: %s", dst.toString()));
+                    logger.info("Move To Trash: {}", dst);
+                    if (!new Trash(fs, conf).moveToTrash(dst)) {
+                        throw new IllegalStateException(String.format("Failed to Move To Trash: %s", dst.toString()));
                     }
-                    logger.debug("MoveToTrash: {}", dst);
                 }
                 FileContext.getFileContext(conf).rename(src, dst, Options.Rename.NONE);
-                logger.debug("Move: {} >>> {}", src, dst);
+                logger.debug("Rename: {} >>> {}", src, dst);
                 return null;
             }
         });

--- a/src/main/java/org/embulk/output/hdfs/compat/ModeCompat.java
+++ b/src/main/java/org/embulk/output/hdfs/compat/ModeCompat.java
@@ -1,0 +1,77 @@
+package org.embulk.output.hdfs.compat;
+
+import com.google.common.base.Optional;
+import org.embulk.config.ConfigException;
+import org.embulk.output.hdfs.ModeTask;
+import org.embulk.output.hdfs.ModeTask.Mode;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+import static org.embulk.output.hdfs.HdfsFileOutputPlugin.PluginTask.DeleteInAdvancePolicy;
+import static org.embulk.output.hdfs.ModeTask.Mode.ABORT_IF_EXIST;
+import static org.embulk.output.hdfs.ModeTask.Mode.DELETE_FILES_IN_ADVANCE;
+import static org.embulk.output.hdfs.ModeTask.Mode.DELETE_RECURSIVE_IN_ADVANCE;
+import static org.embulk.output.hdfs.ModeTask.Mode.OVERWRITE;
+
+@Deprecated
+public class ModeCompat
+{
+    private static final Logger logger = Exec.getLogger(ModeCompat.class);
+
+    private ModeCompat()
+    {
+    }
+
+    @Deprecated
+    public static Mode getMode(
+            ModeTask task,
+            Optional<Boolean> overwrite,
+            Optional<DeleteInAdvancePolicy> deleteInAdvancePolicy)
+    {
+        if (!overwrite.isPresent() && !deleteInAdvancePolicy.isPresent()) {
+            return task.getMode();
+        }
+
+        // Display Deprecated Messages
+        if (overwrite.isPresent()) {
+            logger.warn("`overwrite` option is Deprecated. Please use `mode` option instead.");
+        }
+        if (deleteInAdvancePolicy.isPresent()) {
+            logger.warn("`delete_in_advance` is Deprecated. Please use `mode` option instead.");
+        }
+        if (!task.getMode().isDefaultMode()) {
+            String msg = "`mode` option cannot be used with `overwrite` option or `delete_in_advance` option.";
+            logger.error(msg);
+            throw new ConfigException(msg);
+        }
+
+
+        // Select Mode for Compatibility
+        if (!deleteInAdvancePolicy.isPresent()) {
+            if (overwrite.get()) {
+                logger.warn(String.format("Select `mode: %s` for compatibility", OVERWRITE.toString()));
+                return OVERWRITE;
+            }
+            logger.warn(String.format("Select `mode: %s` for compatibility", ABORT_IF_EXIST.toString()));
+            return ABORT_IF_EXIST;
+        }
+
+        switch (deleteInAdvancePolicy.get()) {  // deleteInAdvancePolicy is always present.
+            case NONE:
+                if (overwrite.isPresent() && overwrite.get()) {
+                    logger.warn(String.format("Select `mode: %s` for compatibility", OVERWRITE.toString()));
+                    return OVERWRITE;
+                }
+                logger.warn(String.format("Select `mode: %s` for compatibility", ABORT_IF_EXIST.toString()));
+                return ABORT_IF_EXIST;
+            case FILE_ONLY:
+                logger.warn(String.format("Select `mode: %s` for compatibility", DELETE_FILES_IN_ADVANCE.toString()));
+                return DELETE_FILES_IN_ADVANCE;
+            case RECURSIVE:
+                logger.warn(String.format("Select `mode: %s` for compatibility", DELETE_RECURSIVE_IN_ADVANCE.toString()));
+                return DELETE_RECURSIVE_IN_ADVANCE;
+            default:
+                throw new ConfigException(String.format("Unknown policy: %s", deleteInAdvancePolicy.get()));
+        }
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/compat/ModeCompat.java
+++ b/src/main/java/org/embulk/output/hdfs/compat/ModeCompat.java
@@ -45,7 +45,6 @@ public class ModeCompat
             throw new ConfigException(msg);
         }
 
-
         // Select Mode for Compatibility
         if (!deleteInAdvancePolicy.isPresent()) {
             if (overwrite.get()) {

--- a/src/main/java/org/embulk/output/hdfs/transaction/AbortIfExistTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/AbortIfExistTx.java
@@ -1,0 +1,12 @@
+package org.embulk.output.hdfs.transaction;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskReport;
+import org.embulk.output.hdfs.HdfsFileOutputPlugin;
+
+import java.util.List;
+
+public class AbortIfExistTx
+        extends AbstractTx
+{
+}

--- a/src/main/java/org/embulk/output/hdfs/transaction/AbortIfExistTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/AbortIfExistTx.java
@@ -1,11 +1,5 @@
 package org.embulk.output.hdfs.transaction;
 
-import org.embulk.config.ConfigDiff;
-import org.embulk.config.TaskReport;
-import org.embulk.output.hdfs.HdfsFileOutputPlugin;
-
-import java.util.List;
-
 public class AbortIfExistTx
         extends AbstractTx
 {

--- a/src/main/java/org/embulk/output/hdfs/transaction/AbstractTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/AbstractTx.java
@@ -1,0 +1,53 @@
+package org.embulk.output.hdfs.transaction;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.output.hdfs.HdfsFileOutput;
+import org.embulk.output.hdfs.util.StrftimeUtil;
+import org.embulk.spi.Exec;
+import org.embulk.spi.TransactionalFileOutput;
+
+import java.util.List;
+
+import static org.embulk.output.hdfs.HdfsFileOutputPlugin.PluginTask;
+
+abstract class AbstractTx
+        implements Tx
+{
+    protected void beforeRun(PluginTask task)
+    {
+    }
+
+    protected void afterRun(PluginTask task, List<TaskReport> reports)
+    {
+    }
+
+    protected ConfigDiff newConfigDiff()
+    {
+        return Exec.newConfigDiff();
+    }
+
+    public ConfigDiff transaction(PluginTask task, ControlRun control)
+    {
+        beforeRun(task);
+        List<TaskReport> reports = control.run();
+        afterRun(task, reports);
+        return newConfigDiff();
+    }
+
+    protected String getPathPrefix(PluginTask task)
+    {
+        return StrftimeUtil.strftime(task.getPathPrefix(), task.getRewindSeconds());
+    }
+
+    protected boolean canOverwrite()
+    {
+        return false;
+    }
+
+    public TransactionalFileOutput newOutput(PluginTask task, TaskSource taskSource, int taskIndex)
+    {
+        return new HdfsFileOutput(task, getPathPrefix(task), canOverwrite(), taskIndex);
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/transaction/ControlRun.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/ControlRun.java
@@ -1,0 +1,10 @@
+package org.embulk.output.hdfs.transaction;
+
+import org.embulk.config.TaskReport;
+
+import java.util.List;
+
+public interface ControlRun
+{
+    List<TaskReport> run();
+}

--- a/src/main/java/org/embulk/output/hdfs/transaction/DeleteFilesInAdvanceTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/DeleteFilesInAdvanceTx.java
@@ -1,13 +1,10 @@
 package org.embulk.output.hdfs.transaction;
 
 import org.apache.hadoop.fs.Path;
-import org.embulk.config.TaskReport;
 import org.embulk.output.hdfs.HdfsFileOutputPlugin;
 import org.embulk.output.hdfs.client.HdfsClient;
 import org.embulk.spi.Exec;
 import org.slf4j.Logger;
-
-import java.util.List;
 
 public class DeleteFilesInAdvanceTx
         extends AbstractTx
@@ -20,6 +17,6 @@ public class DeleteFilesInAdvanceTx
         HdfsClient hdfsClient = HdfsClient.build(task);
         Path globPath = new Path(getPathPrefix(task) + "*");
         logger.info("Delete {} (File Only) in advance", globPath);
-        hdfsClient.globAndRemove(globPath);
+        hdfsClient.globFilesAndTrash(globPath);
     }
 }

--- a/src/main/java/org/embulk/output/hdfs/transaction/DeleteFilesInAdvanceTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/DeleteFilesInAdvanceTx.java
@@ -1,0 +1,25 @@
+package org.embulk.output.hdfs.transaction;
+
+import org.apache.hadoop.fs.Path;
+import org.embulk.config.TaskReport;
+import org.embulk.output.hdfs.HdfsFileOutputPlugin;
+import org.embulk.output.hdfs.client.HdfsClient;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+public class DeleteFilesInAdvanceTx
+        extends AbstractTx
+{
+    private static final Logger logger = Exec.getLogger(DeleteFilesInAdvanceTx.class);
+
+    @Override
+    protected void beforeRun(HdfsFileOutputPlugin.PluginTask task)
+    {
+        HdfsClient hdfsClient = HdfsClient.build(task);
+        Path globPath = new Path(getPathPrefix(task) + "*");
+        logger.info("Delete {} (File Only) in advance", globPath);
+        hdfsClient.globAndRemove(globPath);
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/transaction/DeleteRecursiveInAdvanceTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/DeleteRecursiveInAdvanceTx.java
@@ -17,6 +17,6 @@ public class DeleteRecursiveInAdvanceTx
         HdfsClient hdfsClient = HdfsClient.build(task);
         Path globPath = new Path(getPathPrefix(task) + "*");
         logger.info("Delete {} (Recursive) in advance", globPath);
-        hdfsClient.globAndRemoveRecursive(globPath);
+        hdfsClient.globAndTrash(globPath);
     }
 }

--- a/src/main/java/org/embulk/output/hdfs/transaction/DeleteRecursiveInAdvanceTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/DeleteRecursiveInAdvanceTx.java
@@ -1,0 +1,22 @@
+package org.embulk.output.hdfs.transaction;
+
+import org.apache.hadoop.fs.Path;
+import org.embulk.output.hdfs.HdfsFileOutputPlugin;
+import org.embulk.output.hdfs.client.HdfsClient;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+public class DeleteRecursiveInAdvanceTx
+        extends AbstractTx
+{
+    private static final Logger logger = Exec.getLogger(DeleteRecursiveInAdvanceTx.class);
+
+    @Override
+    protected void beforeRun(HdfsFileOutputPlugin.PluginTask task)
+    {
+        HdfsClient hdfsClient = HdfsClient.build(task);
+        Path globPath = new Path(getPathPrefix(task) + "*");
+        logger.info("Delete {} (Recursive) in advance", globPath);
+        hdfsClient.globAndRemoveRecursive(globPath);
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/transaction/OverwriteTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/OverwriteTx.java
@@ -1,0 +1,11 @@
+package org.embulk.output.hdfs.transaction;
+
+public class OverwriteTx
+        extends AbstractTx
+{
+    @Override
+    protected boolean canOverwrite()
+    {
+        return true;
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/transaction/ReplaceTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/ReplaceTx.java
@@ -59,5 +59,4 @@ public class ReplaceTx
         String pathPrefix = StrftimeUtil.strftime(task.getPathPrefix(), task.getRewindSeconds());
         return SamplePath.getDir(pathPrefix, task.getSequenceFormat(), task.getFileExt());
     }
-
 }

--- a/src/main/java/org/embulk/output/hdfs/transaction/ReplaceTx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/ReplaceTx.java
@@ -1,0 +1,63 @@
+package org.embulk.output.hdfs.transaction;
+
+import org.embulk.config.ConfigException;
+import org.embulk.config.TaskReport;
+import org.embulk.output.hdfs.HdfsFileOutputPlugin.PluginTask;
+import org.embulk.output.hdfs.client.HdfsClient;
+import org.embulk.output.hdfs.util.SafeWorkspaceName;
+import org.embulk.output.hdfs.util.SamplePath;
+import org.embulk.output.hdfs.util.StrftimeUtil;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+public class ReplaceTx
+        extends AbstractTx
+{
+    private static final Logger logger = Exec.getLogger(ReplaceTx.class);
+
+    @Override
+    protected String getPathPrefix(PluginTask task)
+    {
+        return Paths.get(task.getSafeWorkspace(), super.getPathPrefix(task)).toString();
+    }
+
+    @Override
+    protected void beforeRun(PluginTask task)
+    {
+        HdfsClient hdfsClient = HdfsClient.build(task);
+        if (task.getSequenceFormat().contains("/")) {
+            throw new ConfigException("Must not include `/` in `sequence_format` if atomic is true.");
+        }
+
+        String safeWorkspace = SafeWorkspaceName.build(task.getWorkspace());
+        logger.info("Use as a workspace: {}", safeWorkspace);
+
+        String safeWsWithOutput = Paths.get(safeWorkspace, getOutputSampleDir(task)).toString();
+        logger.debug("The actual workspace must be with output dirs: {}", safeWsWithOutput);
+        if (!hdfsClient.mkdirs(safeWsWithOutput)) {
+            throw new ConfigException(String.format("Failed to make a directory: %s", safeWsWithOutput));
+        }
+        task.setSafeWorkspace(safeWorkspace);
+    }
+
+    @Override
+    protected void afterRun(PluginTask task, List<TaskReport> reports)
+    {
+        HdfsClient hdfsClient = HdfsClient.build(task);
+        String outputDir = getOutputSampleDir(task);
+        String safeWsWithOutput = Paths.get(task.getSafeWorkspace(), getOutputSampleDir(task)).toString();
+
+        hdfsClient.renameDirectory(safeWsWithOutput, outputDir, true);
+        logger.info("Store: {} >>> {}", safeWsWithOutput, outputDir);
+    }
+
+    private String getOutputSampleDir(PluginTask task)
+    {
+        String pathPrefix = StrftimeUtil.strftime(task.getPathPrefix(), task.getRewindSeconds());
+        return SamplePath.getDir(pathPrefix, task.getSequenceFormat(), task.getFileExt());
+    }
+
+}

--- a/src/main/java/org/embulk/output/hdfs/transaction/Tx.java
+++ b/src/main/java/org/embulk/output/hdfs/transaction/Tx.java
@@ -1,0 +1,13 @@
+package org.embulk.output.hdfs.transaction;
+
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskSource;
+import org.embulk.output.hdfs.HdfsFileOutputPlugin.PluginTask;
+import org.embulk.spi.TransactionalFileOutput;
+
+public interface Tx
+{
+    ConfigDiff transaction(PluginTask task, ControlRun control);
+
+    TransactionalFileOutput newOutput(PluginTask task, TaskSource taskSource, int taskIndex);
+}

--- a/src/main/java/org/embulk/output/hdfs/util/SafeWorkspaceName.java
+++ b/src/main/java/org/embulk/output/hdfs/util/SafeWorkspaceName.java
@@ -1,0 +1,21 @@
+package org.embulk.output.hdfs.util;
+
+import java.nio.file.Paths;
+import java.util.UUID;
+
+public class SafeWorkspaceName
+{
+    private static final String prefix = "embulk-output-hdfs";
+
+    private SafeWorkspaceName()
+    {
+    }
+
+    public static String build(String workspace)
+    {
+        long nanoTime = System.nanoTime();
+        String uuid = UUID.randomUUID().toString();
+        String dirname = String.format("%s_%d_%s", prefix, nanoTime, uuid);
+        return Paths.get(workspace, dirname).toString();
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/util/SamplePath.java
+++ b/src/main/java/org/embulk/output/hdfs/util/SamplePath.java
@@ -1,0 +1,21 @@
+package org.embulk.output.hdfs.util;
+
+import java.nio.file.Paths;
+
+public class SamplePath
+{
+    private SamplePath()
+    {
+    }
+
+    public static String getFile(String pathPrefix, String sequenceFormat, String fileExt)
+    {
+        return pathPrefix + String.format(sequenceFormat, 0, 0) + fileExt;
+    }
+
+    public static String getDir(String pathPrefix, String sequenceFormat, String fileExt)
+    {
+        String sampleFile = getFile(pathPrefix, sequenceFormat, fileExt);
+        return Paths.get(sampleFile).getParent().toString();
+    }
+}

--- a/src/main/java/org/embulk/output/hdfs/util/StrftimeUtil.java
+++ b/src/main/java/org/embulk/output/hdfs/util/StrftimeUtil.java
@@ -1,0 +1,23 @@
+package org.embulk.output.hdfs.util;
+
+import org.jruby.embed.ScriptingContainer;
+
+public class StrftimeUtil
+{
+    private static final String scriptTemplate = "(Time.now - %d).strftime('%s')";
+
+    private StrftimeUtil()
+    {
+    }
+
+    public static String strftime(String format, int rewindSeconds)
+    {
+        String script = buildScript(format, rewindSeconds);
+        return new ScriptingContainer().runScriptlet(script).toString();
+    }
+
+    private static String buildScript(String format, int rewindSeconds)
+    {
+        return String.format(scriptTemplate, rewindSeconds, format);
+    }
+}

--- a/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
@@ -223,8 +223,8 @@ public class TestHdfsFileOutputPlugin
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {
-            tmpFolder.newFile("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_file_" + n + ".txt");
-            tmpFolder.newFolder("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_directory_" + n);
+            tmpFolder.newFile("embulk-output-hdfs_file_" + n + ".txt");
+            tmpFolder.newFolder("embulk-output-hdfs_directory_" + n);
         }
 
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
@@ -240,7 +240,7 @@ public class TestHdfsFileOutputPlugin
 
         List<String> fileListAfterRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
         assertNotEquals(fileListBeforeRun, fileListAfterRun);
-        assertThat(fileListAfterRun, not(hasItem(containsString("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_directory_"))));
+        assertThat(fileListAfterRun, not(hasItem(containsString("embulk-output-hdfs_directory"))));
         assertThat(fileListAfterRun, not(hasItem(containsString("txt"))));
         assertThat(fileListAfterRun, hasItem(containsString(pathPrefix + "001.00.csv")));
         assertRecordsInFile(String.format("%s/%s001.00.csv",
@@ -253,8 +253,8 @@ public class TestHdfsFileOutputPlugin
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {
-            tmpFolder.newFile("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_file_" + n + ".txt");
-            tmpFolder.newFolder("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_directory_" + n);
+            tmpFolder.newFile("embulk-output-hdfs_file_" + n + ".txt");
+            tmpFolder.newFolder("embulk-output-hdfs_directory_" + n);
         }
 
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
@@ -271,7 +271,7 @@ public class TestHdfsFileOutputPlugin
         List<String> fileListAfterRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
         assertNotEquals(fileListBeforeRun, fileListAfterRun);
         assertThat(fileListAfterRun, not(hasItem(containsString("txt"))));
-        assertThat(fileListAfterRun, hasItem(containsString("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_directory_")));
+        assertThat(fileListAfterRun, hasItem(containsString("embulk-output-hdfs_directory")));
         assertThat(fileListAfterRun, hasItem(containsString(pathPrefix + "001.00.csv")));
         assertRecordsInFile(String.format("%s/%s001.00.csv",
                 tmpFolder.getRoot().getAbsolutePath(),

--- a/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
@@ -201,14 +201,20 @@ public class TestHdfsFileOutputPlugin
         }
     }
 
+    private ConfigSource getDefaultFsConfig()
+    {
+        return Exec.newConfigSource()
+                .set("fs.hdfs.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
+                .set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
+                .set("fs.trash.interval", "3600")
+                .set("fs.defaultFS", "file:///");
+    }
+
     @Test
     public void testBulkLoad()
     {
         ConfigSource config = getBaseConfigSource()
-                .setNested("config", Exec.newConfigSource()
-                        .set("fs.hdfs.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
-                        .set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
-                        .set("fs.defaultFS", "file:///"));
+                .setNested("config", getDefaultFsConfig());
 
         run(config);
         List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
@@ -230,10 +236,7 @@ public class TestHdfsFileOutputPlugin
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
 
         ConfigSource config = getBaseConfigSource()
-                .setNested("config", Exec.newConfigSource()
-                        .set("fs.hdfs.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
-                        .set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
-                        .set("fs.defaultFS", "file:///"))
+                .setNested("config", getDefaultFsConfig())
                 .set("delete_in_advance", "RECURSIVE");
 
         run(config);
@@ -260,10 +263,7 @@ public class TestHdfsFileOutputPlugin
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
 
         ConfigSource config = getBaseConfigSource()
-                .setNested("config", Exec.newConfigSource()
-                        .set("fs.hdfs.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
-                        .set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem")
-                        .set("fs.defaultFS", "file:///"))
+                .setNested("config", getDefaultFsConfig())
                 .set("delete_in_advance", "FILE_ONLY");
 
         run(config);

--- a/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
@@ -223,8 +223,8 @@ public class TestHdfsFileOutputPlugin
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {
-            tmpFolder.newFile("embulk-output-hdfs_file_" + n + ".txt");
-            tmpFolder.newFolder("embulk-output-hdfs_directory_" + n);
+            tmpFolder.newFile("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_file_" + n + ".txt");
+            tmpFolder.newFolder("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_directory_" + n);
         }
 
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
@@ -240,7 +240,7 @@ public class TestHdfsFileOutputPlugin
 
         List<String> fileListAfterRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
         assertNotEquals(fileListBeforeRun, fileListAfterRun);
-        assertThat(fileListAfterRun, not(hasItem(containsString("embulk-output-hdfs_directory"))));
+        assertThat(fileListAfterRun, not(hasItem(containsString("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_directory_"))));
         assertThat(fileListAfterRun, not(hasItem(containsString("txt"))));
         assertThat(fileListAfterRun, hasItem(containsString(pathPrefix + "001.00.csv")));
         assertRecordsInFile(String.format("%s/%s001.00.csv",
@@ -253,8 +253,8 @@ public class TestHdfsFileOutputPlugin
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {
-            tmpFolder.newFile("embulk-output-hdfs_file_" + n + ".txt");
-            tmpFolder.newFolder("embulk-output-hdfs_directory_" + n);
+            tmpFolder.newFile("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_file_" + n + ".txt");
+            tmpFolder.newFolder("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_directory_" + n);
         }
 
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
@@ -271,7 +271,7 @@ public class TestHdfsFileOutputPlugin
         List<String> fileListAfterRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
         assertNotEquals(fileListBeforeRun, fileListAfterRun);
         assertThat(fileListAfterRun, not(hasItem(containsString("txt"))));
-        assertThat(fileListAfterRun, hasItem(containsString("embulk-output-hdfs_directory")));
+        assertThat(fileListAfterRun, hasItem(containsString("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_directory_")));
         assertThat(fileListAfterRun, hasItem(containsString(pathPrefix + "001.00.csv")));
         assertRecordsInFile(String.format("%s/%s001.00.csv",
                 tmpFolder.getRoot().getAbsolutePath(),

--- a/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
@@ -229,8 +229,8 @@ public class TestHdfsFileOutputPlugin
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {
-            tmpFolder.newFile("embulk-output-hdfs_file_" + n + ".txt");
-            tmpFolder.newFolder("embulk-output-hdfs_directory_" + n);
+            tmpFolder.newFile("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_file_" + n + ".txt");
+            tmpFolder.newFolder("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_directory_" + n);
         }
 
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
@@ -243,7 +243,7 @@ public class TestHdfsFileOutputPlugin
 
         List<String> fileListAfterRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
         assertNotEquals(fileListBeforeRun, fileListAfterRun);
-        assertThat(fileListAfterRun, not(hasItem(containsString("embulk-output-hdfs_directory"))));
+        assertThat(fileListAfterRun, not(hasItem(containsString("embulk-output-hdfs_testDeleteInAdvance_RECURSIVE_directory_"))));
         assertThat(fileListAfterRun, not(hasItem(containsString("txt"))));
         assertThat(fileListAfterRun, hasItem(containsString(pathPrefix + "001.00.csv")));
         assertRecordsInFile(String.format("%s/%s001.00.csv",
@@ -256,8 +256,8 @@ public class TestHdfsFileOutputPlugin
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {
-            tmpFolder.newFile("embulk-output-hdfs_file_" + n + ".txt");
-            tmpFolder.newFolder("embulk-output-hdfs_directory_" + n);
+            tmpFolder.newFile("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_file_" + n + ".txt");
+            tmpFolder.newFolder("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_directory_" + n);
         }
 
         List<String> fileListBeforeRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
@@ -271,7 +271,7 @@ public class TestHdfsFileOutputPlugin
         List<String> fileListAfterRun = lsR(Lists.<String>newArrayList(), Paths.get(tmpFolder.getRoot().getAbsolutePath()));
         assertNotEquals(fileListBeforeRun, fileListAfterRun);
         assertThat(fileListAfterRun, not(hasItem(containsString("txt"))));
-        assertThat(fileListAfterRun, hasItem(containsString("embulk-output-hdfs_directory")));
+        assertThat(fileListAfterRun, hasItem(containsString("embulk-output-hdfs_testDeleteInAdvance_FILE_ONLY_directory_")));
         assertThat(fileListAfterRun, hasItem(containsString(pathPrefix + "001.00.csv")));
         assertRecordsInFile(String.format("%s/%s001.00.csv",
                 tmpFolder.getRoot().getAbsolutePath(),

--- a/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
@@ -107,9 +107,9 @@ public class TestHdfsFileOutputPlugin
         assertEquals(Lists.newArrayList(), task.getConfigFiles());
         assertEquals(Maps.newHashMap(), task.getConfig());
         assertEquals(0, task.getRewindSeconds());
-        assertEquals(false, task.getOverwrite());
+        assertEquals(Optional.absent(), task.getOverwrite());
         assertEquals(Optional.absent(), task.getDoas());
-        assertEquals(PluginTask.DeleteInAdvancePolicy.NONE, task.getDeleteInAdvance());
+        assertEquals(Optional.absent(), task.getDeleteInAdvance());
     }
 
     @Test(expected = ConfigException.class)

--- a/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/hdfs/TestHdfsFileOutputPlugin.java
@@ -219,7 +219,7 @@ public class TestHdfsFileOutputPlugin
     }
 
     @Test
-    public void testDeleteRECURSIVEInAdvance()
+    public void testDeleteInAdvance_RECURSIVE()
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {
@@ -249,7 +249,7 @@ public class TestHdfsFileOutputPlugin
     }
 
     @Test
-    public void testDeleteFILE_ONLYInAdvance()
+    public void testDeleteInAdvance_FILE_ONLY()
             throws IOException
     {
         for (int n = 0; n <= 10; n++) {


### PR DESCRIPTION
I implement atomic replace mode. Users cam replace output files(Exactly a directory, but) atomically if the output already exists.

TODO:
- [x] ~Do debug after resolving https://github.com/embulk/embulk/issues/658~ Should do replacing in `transaction`, so https://github.com/embulk/embulk/issues/658 is not related with this issue.
- [x] Consider the option name
- [x] Write tests