### PR TITLE
Add kerberos keytab authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ A File Output Plugin for Embulk to write HDFS.
     - `RECURSIVE`: delete files and directories
 - **mode**: "abort_if_exist", "overwrite", "delete_files_in_advance", "delete_recursive_in_advance", or "replace". See below. (string, optional, default: `"abort_if_exist"`)
     * In the future, default mode will become `"replace"`.
+- **keytab_config**: For keytab auth for kerberos. see https://docs.cloudera.com/documentation/enterprise/6/6.2/topics/cdh_sg_princ_auth_java.html (hash, default: `{}`)
+  - **krb5_config_path**: krb5.conf file path (string, optional)
+  - **keytab_principal**: user principal (string, optional)
+  - **keytab_path**: Keytab file path (string, optional)
 
 ## CAUTION
 If you use `hadoop` user (hdfs admin user) as `doas`, and if `delete_in_advance` is `RECURSIVE`,

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ configurations {
     provided
 }
 
-version = "0.4.0.pre"
+version = "0.4.1.pre"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ configurations {
     provided
 }
 
-version = "0.4.1.pre"
+version = "0.4.2.pre"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -59,18 +59,9 @@ public class HdfsFileOutputPlugin
         @ConfigDefault("null")
         Optional<String> getDoas();
 
-        @Config("krb5_config_path")
-        @ConfigDefault("null")
-        Optional<String> getKrb5ConfigPath();
-
-        @Config("keytab_principal")
-        @ConfigDefault("null")
-        Optional<String> getKeytabPrincipal();
-
-        @Config("keytab_path")
-        @ConfigDefault("null")
-        Optional<String> getKeytabPath();
-
+        @Config("keytab_config")
+        @ConfigDefault("{}")
+        Map<String, String> getKeytabConfig();
         @Deprecated
         enum DeleteInAdvancePolicy
         {

--- a/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/hdfs/HdfsFileOutputPlugin.java
@@ -59,6 +59,18 @@ public class HdfsFileOutputPlugin
         @ConfigDefault("null")
         Optional<String> getDoas();
 
+        @Config("krb5_config_path")
+        @ConfigDefault("null")
+        Optional<String> getKrb5ConfigPath();
+
+        @Config("keytab_principal")
+        @ConfigDefault("null")
+        Optional<String> getKeytabPrincipal();
+
+        @Config("keytab_path")
+        @ConfigDefault("null")
+        Optional<String> getKeytabPath();
+
         @Deprecated
         enum DeleteInAdvancePolicy
         {

--- a/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
+++ b/src/main/java/org/embulk/output/hdfs/client/HdfsClient.java
@@ -29,8 +29,8 @@ public class HdfsClient
 {
     public static HdfsClient build(HdfsFileOutputPlugin.PluginTask task)
     {
-        setKerberosKeytabAuthention(task.getKeytabConfig());
         Configuration conf = buildConfiguration(task.getConfigFiles(), task.getConfig());
+        setKerberosKeytabAuthention(conf, task.getKeytabConfig());
         return new HdfsClient(conf, task.getDoas());
     }
 
@@ -39,8 +39,9 @@ public class HdfsClient
     /**
      * https://docs.cloudera.com/documentation/enterprise/6/6.2/topics/cdh_sg_princ_auth_java.html
      */
-    public static void setKerberosKeytabAuthention(Map<String, String> keytabConfig){
+    public static void setKerberosKeytabAuthention(Configuration conf, Map<String, String> keytabConfig){
         if(keytabConfig == null || keytabConfig.size() == 0){
+            UserGroupInformation.setConfiguration(conf);
             return;
         }
         String krb5ConfigPath = keytabConfig.get("krb5_config_path");
@@ -57,6 +58,7 @@ public class HdfsClient
 
         try {
             System.setProperty("java.security.krb5.conf", krb5ConfigPath);
+            UserGroupInformation.setConfiguration(conf);
             UserGroupInformation.loginUserFromKeytab(keytabPrincipal, keytabPath);
         } catch (IOException e) {
             throw new ConfigException(e);
@@ -81,7 +83,6 @@ public class HdfsClient
         for (Map.Entry<String, String> config : configs.entrySet()) {
             c.set(config.getKey(), config.getValue());
         }
-        UserGroupInformation.setConfiguration(c);
         return c;
     }
 


### PR DESCRIPTION
Thank you for your great work. embulk-output-hdfs is very cool plugin.
I want to add some feature - kerberos keytab auth.
use like this.

- command line auth

```
kinit -kt user.keytab user
```

- embulk yaml file 

```
out:
  ....
  type: hdfs
  path_prefix: ./testdata
  file_ext: tsv
  config_files:
    - ./hadoop-conf/core-site.xml
    - ./hadoop-conf/hdfs-site.xml
  doas: user
  keytab_config:
    keytab_path: ./env/user.keytab
    keytab_principal: user@CLOUDERA.COM
    krb5_config_path: ./env/krb5.conf
  config:
    fs.defaultFS: 'webhdfs://my-hadoop-server:9870'
    fs.webhdfs.impl: 'org.apache.hadoop.hdfs.web.WebHdfsFileSystem'
    hadoop.security.authentication: 'kerberos'
    hadoop.security.authorization: 'true'
    dfs.client.use.datanode.hostname: 'true'
    dfs.namenode.kerberos.principal.pattern: 'hdfs/*@CLOUDERA.COM'    
   ....
```

This pull request's implementation is working fine in my environment with "webhdfs"

